### PR TITLE
Add TravisCI build script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+sudo: required
+dist: bionic
+before_install:
+  - sudo apt-get -qq update && sudo apt-get install -y --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended latexmk inkscape
+
+install:
+  - pip install -r requirements.txt
+
+script:
+  - export LATEXOPTS="--interaction=nonstopmode"
+  - ( cd cores/cv32e40p/user_manual && sphinx-build -M html source build -nWT )
+  - ( cd cores/cv32e40p/user_manual && sphinx-build -M latexpdf source build -nWT )

--- a/cores/cv32e40p/user_manual/source/conf.py
+++ b/cores/cv32e40p/user_manual/source/conf.py
@@ -42,6 +42,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.todo',
     'recommonmark',
+    'sphinxcontrib.inkscapeconverter',
 #    'sphinxcontrib.wavedrom',
 ]
 #wavedrom_html_jsinline = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+sphinx-rtd-theme
+recommonmark
+sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
This will try to build the HTML and PDF documentation. It runs the build in "nit-picky" mode and converts warnings into errors. It actually fails the PDF generation due to the SVG used in the section about OBI. Not sure what you would want to do about that.

It would be good to add this as a check for PRs.

Example build: https://travis-ci.com/github/emmicro-us/core-v-docs/builds/172578562