### PR TITLE
Clarify writes of non-supported values to WLRL fields do not throw an illegal instruction exception.

### DIFF
--- a/cores/cv32e40p/user_manual/source/control_status_registers.rst
+++ b/cores/cv32e40p/user_manual/source/control_status_registers.rst
@@ -9,6 +9,9 @@ that were needed for the PULP system. The reason for this is that we
 wanted to keep the footprint of the core as low as possible and avoid
 any overhead that we do not explicitly need.
 
+Writes of a non-supported value to a CSR does not throw an illegal
+instruction exception.
+
 +---------------+-------------------+-----------+---------------------------------------------------------+
 |  CSR Address  |   Name            | Privilege |   Description                                           |
 +---------------+-------------------+-----------+---------------------------------------------------------+


### PR DESCRIPTION
In section 2.3 of the RISC-V specification it states:

> Implementations are permitted but not required to raise an illegal
instruction exception if an instruction attempts to write a
non-supported value to a WLRL field.

This line in the documentation clarifies this implementation choice.

Signed-off-by: John Eric Martin <John.Martin@emmicro-us.com>