### PR TITLE
Create Software TG attendance framework

### DIFF
--- a/program/TGSoftware_Attendance_2020.md
+++ b/program/TGSoftware_Attendance_2020.md
@@ -1,0 +1,89 @@
+## Software TG Attendance Tracker Template
+
+**Member Attendance Master Table**
+
+| Company            |  Person           |20.05.11|20.06.08|20.07.13|20.08.10|20.MM.DD|
+|--------------------|-------------------|:------:|:------:|:------:|:------:|:------:|
+| AB Open Ltd        |                   |        |        |        |        |        |
+| Alibaba Group      | Yunshai Shang     | Y      | Y      | Y      |        |        |
+| Alibaba Group      | Xiaoning Qi       |        |        |        |        |        |
+| Ashling Micro. Ltd |                   |        |        |        |        |        |
+| Barcelona Sup.(BSC)|                   |        |        |        |        |        |
+| Bluespec Inc       | Charlie Hauck     |        |        |        |        |        |
+| BTA Dsgn Svcs Inc  |                   |        |        |        |        |        |
+| CMC Microsystems   | Kevin Dobie       |        |        |        |        |        |
+| CMC Microsystems   | H. Pollitt-Smith  |        |        |        |        |        |
+| Ecole de Tech.Sup. |                   |        |        |        |        |        |
+| ECSPEC             |                   |        |        |        |        |        |
+| EM Micro. US Inc   | John Martin       |        |        |        |        |        |
+| EM Micro. US Inc   | David McConnell   |        |        |        |        |        |
+| EM Micro. US Inc   | Greg Tumbush      |        |        |        |        |        |
+| Embecosm           | Jeremy Bennett    | Y      | Y      | Y      |        |        |
+| Embecosm           | Mary Bennett      |        |        |        |        |        |
+| Embecosm           | Craig Blackmore   | Y      | Y      | Y      |        |        |
+| Embecosm           | Pietra Ferreira   |        |        |        |        |        |
+| Embecosm           | Jessica Mills     |        |        |        |        |        |
+| Embecosm           | Paolo Savini      |        | Y      | Y      |        |        |
+| ETH Zurich         |                   |        |        |        |        |        |
+| Futurewei Tech. Inc| Jiangliang Wang   |        |        |        |        |        |
+| Futurewei Tech. Inc| Hansheng Tan      |        |        |        |        |        |
+| Global Foundries   |                   |        |        |        |        |        |
+| GreenWaves Tech.   |                   |        |        |        |        |        |
+| Hensoldt Cyber GmbH| Mass. Giacometti  |        |        |        |        |        |
+| Hensoldt Cyber GmbH| Marco Sabatano    |        |        |        |        |        |
+| Huawei             |                   |        |        |        |        |        |
+| IAR Systems Grp. AB|                   |        |        |        |        |        |
+| Imperas Sw. Ltd    | Simon Davidmann   |        |        |        |        |        |
+| Imperas Sw. Ltd    | Duncan Graham     |        |        |        |        |        |
+| Imperas Sw. Ltd    | Lee Moore         |        |        |        |        |        |
+| Metrics Tech. Inc  |                   |        |        |        |        |        |
+| Mitacs             | Mel Chaar         |        |        |        |        |        |
+| MNT Research GmbH  |                   |        |        |        |        |        |
+| NVIDIA             |                   |        |        |        |        |        |
+| NXP USA, Inc.      | Vitor Eschholz    |        |        |        |        |        |
+| NXP USA, Inc.      | Vitor Sato        |        |        |        |        |        |
+| NXP USA, Inc.      | Jerry Zeng        |        | Y      |        |        |        |
+| OneSpin            | Sven Beyer        |        |        |        |        |        |
+| OneSpin            | Sal. Hetalani     |        |        |        |        |        |
+| OneSpin            | Nic. Tunsinschi   |        |        |        |        |        |
+| OPERSYS Inc.       |                   |        |        |        |        |        |
+| Pingtouge Semi.Ltd |                   |        |        |        |        |        |
+| Polytechnique Mtrl.|                   |        |        |        |        |        |
+| Praesum Comm.      |                   |        |        |        |        |        |
+| Secure Thingz      |                   |        |        |        |        |        |
+| Silicon Labs. Inc. | Sebastian Ahmed   |        |        |        |        |        |
+| Silicon Labs. Inc. | Arjan Bink        | Y      | Y      |        |        |        |
+| Silicon Labs. Inc. | Oystein Knauserud |        |        |        |        |        |
+| Silicon Labs. Inc. | A. Piovaccari     |        |        |        |        |        |
+| Silicon Labs. Inc. | Steve Richmond    |        |        |        |        |        |
+| Silicon Labs. Inc. | Paul Zavalney     |        | Y      |        |        |        |
+| Symbiotic GmbH     | Nina Engelhardt   |        |        |        |        |        |
+| Thales             | Jerome Quevremont |        |        |        |        |        |
+| Thales             | Zbigniew Chamski  | Y      | Y      |  Y     |        |        |
+| Thales             | Jean-Roch Coulon  |        |        |        |        |        |
+| Univ. of Utah      |                   |        |        |        |        |        |
+| Symbiotic GmbH     |                   |        |        |        |        |        |
+| UltraSoC Tech. Ltd |                   |        |        |        |        |        |
+| Univ. of Bologna   |                   |        |        |        |        |        |
+| Univ. of Ottawa    |                   |        |        |        |        |        |
+| Univ. of Toronto   |                   |        |        |        |        |        |
+| Verifai Inc.       |                   |        |        |        |        |        |
+| VeriSilicon        | Wayne Dai         |        |        |        |        |        |
+
+**Guest/Non-Member Attendance Table**
+
+| Company            |  Person           |20.05.11|20.06.08|20.07.13|20.08.10|20.MM.DD|
+|--------------------|-------------------|:------:|:------:|:------:|:------:|:------:|
+| Eclipse project    | Alexander Fedorov | Y      | Y      | Y      |        |        |
+| Publitek           | Andrea Barnard    |        |        | Y      |        |        |
+
+**OpenHW Attendance Table**
+
+| Company            |  Person           |20.05.11|20.06.08|20.07.13|20.08.10|20.MM.DD|
+|--------------------|-------------------|:------:|:------:|:------:|:------:|:------:|
+| OpenHW             | Duncan Bees       |        |        | Y      |        |        |
+| OpenHW             | Rick O'Connor     | Y      |        |        |        |        |
+| OpenHW             | Jim Parisien      | Y      | Y      |        |        |        |
+| OpenHW             | Davide Schiavone  |        |        |        |        |        |
+| OpenHW             | Mike Thompson     | Y      | Y      | Y      |        |        |
+| OpenHW             | Florian Zaruba    |        |        | Y      |        |        |


### PR DESCRIPTION
	This follows the guidance from Duncan Bees and incorporates legacy
	information which has already been published in meeting minutes.

Files changed:

	* program/TGSoftware_Attendance_2020.md: Created.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>