### PR TITLE
Clean up SW TG Attendance

### DIFF
--- a/program/TGSoftware_Attendance_2020.md
+++ b/program/TGSoftware_Attendance_2020.md
@@ -1,40 +1,43 @@
 ## Software TG Attendance Tracker Template
 
-**Member Attendance Master Table**
+Only full meetings are shown. Subgroup meetings, joint meetings with other
+groups are excluded.
 
-| Company            |  Person           |20.05.11|20.06.08|20.07.13|20.08.10|20.08.10|20.MM.DD|
-|--------------------|-------------------|:------:|:------:|:------:|:------:|:------:|:------:|
-| Alibaba Group      | Yunshai Shang     | Y      | Y      | Y      | Y      | Y      |        |
-| Ashling Micro. Ltd | Hugh O'Keefe      |        |        | Y      |        | Y      |        |
-| Ashling Micro. Ltd | Roisin O'Keefe    |        |        |        |        | Y      |        |
-| Ashling Micro. Ltd | Promod            |        |        |        |        | Y      |        |
-| Ashling Micro. Ltd | Rejeesh SB        |        |        | Y      |        |        |        |
-| Embecosm           | Jeremy Bennett    | Y      | Y      | Y      | Y      | Y      |        |
-| Embecosm           | Mary Bennett      |        |        |        | Y      | Y      |        |
-| Embecosm           | Craig Blackmore   | Y      | Y      | Y      | Y      | Y      |        |
-| Embecosm           | Pietra Ferreira   |        |        |        | Y      | Y      |        |
-| Embecosm           | Jessica Mills     |        |        |        | Y      | Y      |        |
-| Embecosm           | Paolo Savini      |        | Y      | Y      |        |        |        |
-| NXP USA, Inc.      | John Waite        |        |        |        |        | Y      |        |
-| NXP USA, Inc.      | Jerry Zeng        |        | Y      |        |        |        |        |
-| Silicon Labs. Inc. | Arjan Bink        | Y      | Y      |        | Y      | Y      |        |
-| Silicon Labs. Inc. | Paul Zavalney     |        | Y      |        |        |        |        |
-| Thales             | Zbigniew Chamski  | Y      | Y      |  Y     | Y      | Y      |        |
+**Software TG Member Attendance Table**
+
+| Company            |  Person           |20.05.11|20.06.08|20.07.13|20.08.10|20.MM.DD|
+|--------------------|-------------------|:------:|:------:|:------:|:------:|:------:|
+| Alibaba Group      | Yunshai Shang     | Y      | Y      | Y      | Y      |        |
+| Ashling Micro. Ltd | Hugh O'Keefe      |        |        | Y      | Y      |        |
+| Ashling Micro. Ltd | Roisin O'Keefe    |        |        |        | Y      |        |
+| Ashling Micro. Ltd | Promod            |        |        |        | Y      |        |
+| Ashling Micro. Ltd | Rejeesh SB        |        |        | Y      |        |        |
+| Embecosm           | Jeremy Bennett    | Y      | Y      | Y      | Y      |        |
+| Embecosm           | Mary Bennett      |        |        |        | Y      |        |
+| Embecosm           | Craig Blackmore   | Y      | Y      | Y      | Y      |        |
+| Embecosm           | Pietra Ferreira   |        |        |        | Y      |        |
+| Embecosm           | Jessica Mills     |        |        |        | Y      |        |
+| Embecosm           | Paolo Savini      |        | Y      | Y      |        |        |
+| NXP USA, Inc.      | John Waite        |        |        |        | Y      |        |
+| NXP USA, Inc.      | Jerry Zeng        |        | Y      |        |        |        |
+| Silicon Labs. Inc. | Arjan Bink        | Y      | Y      |        | Y      |        |
+| Silicon Labs. Inc. | Paul Zavalney     |        | Y      |        |        |        |
+| Thales             | Zbigniew Chamski  | Y      | Y      |  Y     | Y      |        |
 
 **Guest/Non-Member Attendance Table**
 
-| Company            |  Person           |20.05.11|20.06.08|20.07.13|20.08.10|20.08.10|20.MM.DD|
-|--------------------|-------------------|:------:|:------:|:------:|:------:|:------:|:------:|
-| Eclipse project    | Alexander Fedorov | Y      | Y      | Y      |        | Y      |        |
-| Publitek           | Andrea Barnard    |        |        | Y      |        |        |        |
+| Company            |  Person           |20.05.11|20.06.08|20.07.13|20.08.10|20.MM.DD|
+|--------------------|-------------------|:------:|:------:|:------:|:------:|:------:|
+| Eclipse project    | Alexander Fedorov | Y      | Y      | Y      | Y      |        |
+| Publitek           | Andrea Barnard    |        |        | Y      |        |        |
 
 **OpenHW Attendance Table**
 
-| Company            |  Person           |20.05.11|20.06.08|20.07.13|20.08.10|20.08.10|20.MM.DD|
-|--------------------|-------------------|:------:|:------:|:------:|:------:|:------:|:------:|
-| OpenHW             | Duncan Bees       |        |        | Y      |        | Y      |        |
-| OpenHW             | Rick O'Connor     | Y      |        |        |        |        |        |
-| OpenHW             | Jim Parisien      | Y      | Y      |        |        |        |        |
-| OpenHW             | Davide Schiavone  |        |        |        | Y      |        |        |
-| OpenHW             | Mike Thompson     | Y      | Y      | Y      | Y      | Y      |        |
-| OpenHW             | Florian Zaruba    |        |        | Y      |        | Y      |        |
+| Company            |  Person           |20.05.11|20.06.08|20.07.13|20.08.10|20.MM.DD|
+|--------------------|-------------------|:------:|:------:|:------:|:------:|:------:|
+| OpenHW             | Duncan Bees       |        |        | Y      | Y      |        |
+| OpenHW             | Rick O'Connor     | Y      |        |        |        |        |
+| OpenHW             | Jim Parisien      | Y      | Y      |        |        |        |
+| OpenHW             | Davide Schiavone  |        |        |        |        |        |
+| OpenHW             | Mike Thompson     | Y      | Y      | Y      | Y      |        |
+| OpenHW             | Florian Zaruba    |        |        | Y      | Y      |        |


### PR DESCRIPTION
Files changed:

	* program/TGSoftware_Attendance_2020.md: Change table heading to
	be explicitly the SW TG attendance; remove joint meeting with
	Cores TG on 10 Aug 20, since not a full meeting of the group.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>