### PR TITLE
Proposal to add DM

### DIFF
--- a/program/CV32E40Pv2 preliminary project proposal.md
+++ b/program/CV32E40Pv2 preliminary project proposal.md
@@ -46,6 +46,13 @@ The debug trigger implementation should be extended with the following additiona
 * Load/store address breakpoints (break when you access a certain memory address with a load/store instruction)
 * Option to configure the triggers to throw an exception instead of halting the core
 
+#### Debug Module (Documentation, RTL and Verification)
+
+The CV32E40P supports a a debug request input to place the core into debug mode.  The scope of the CV32E40P v2 could be expanded to include a Debug Module compliant with the RISC-V debug specification (v0.13.1 or higher).
+An obvious source for such a DM is the [PULP RISCV-dbg](https://github.com/pulp-platform/riscv-dbg) project.  Other implementation options are also available dependent upon member interest and contributions.
+
+The DM could be tighly integrated into CV32E40P v2 or loosely coupled.
+
 ### FPU (RTL, Verification, Documentation)
 
 The CV32E40P has RTL to instantiate the FPU from the `fpnew` project from ETH. This project remains in the ETH GitHub. It is an implementation of the RISC-V standard FPU extension specification (F extension). It is not supported in the current version of the CV32E40P. The RTL may have become stale; however, the majority of the work will be in the verification and documentation.


### PR DESCRIPTION
Hi @jm4rtin, @davideschiavone, @zarubaf, @Silabs-ArjanB, @jquevremont and @DBees.  This pull-request is in direct response to a conversation in openhwgroup/core-v-verif#65:
> With respect to Debug there is a 'v013.2 Debug Compliance test' that I think would be very valuable to add to core-v-verif. It requires the instantiation of the Debug Module inside the core-v-verif testbench and it will then do a (basic) compliance check of the combination of the RISC-V core and the Debug Module. Maybe this is beyond the scope of the RTL freeze target, but if so, then I would really appreciate if this can be added afterwards as it represents actual usage scenarios of the debug system.

I support this notion, but as a Debug Module is explicitly beyond the scope of CV32E40P, there are no plans to integrate a DM into the testbench and run the 'v013.2 Debug Compliance test'.

The purpose of this pull-request is to re-open that discussion for CV32E40P v2.   I support the notion of defining a "CORE-V Debug Module" that supports all CORE-V cores, not just CV32E4.   However, such a DM would need a first core to use it, so I further propose that the CV32E40P v2 be that core.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>