### PR TITLE
clean FPU doc

### DIFF
--- a/cores/cv32e40p/user_manual/source/control_status_registers.rst
+++ b/cores/cv32e40p/user_manual/source/control_status_registers.rst
@@ -90,10 +90,6 @@ instruction exception.
   +---------------+-------------------+-----------+---------------------+---------------------------------------------------------+
   | 0x806         | ``lpcount1``      | URW       | ``PULP_XPULP`` = 1  | Hardware Loop 1 Counter.                                |
   +---------------+-------------------+-----------+---------------------+---------------------------------------------------------+
-  | 0x807         | ``fprec``         | URW       | ``PULP_XPULP`` = 1  | Custom flag which controls the precision and latency    |
-  |               |                   |           | &&                  | of the iterative div/sqrt unit.                         |
-  |               |                   |           | ``FPU`` = 1         |                                                         |
-  +---------------+-------------------+-----------+---------------------+---------------------------------------------------------+
   | 0xCC0         | ``uhartid``       | URO       | ``PULP_XPULP`` = 1  | Hardware Thread ID                                      |
   +---------------+-------------------+-----------+---------------------+---------------------------------------------------------+
   | 0xCC1         | ``privlv``        | URO       | ``PULP_XPULP`` = 1  | Privilege Level                                         |
@@ -322,35 +318,6 @@ Detailed:
 | 31:0        | RW        | Number of iteration of HWLoop 0/1.        |
 +-------------+-----------+-------------------------------------------+
 
-.. _csr-fprec:
-
-Floating-point precision (``fprec``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-CSR Address: 0x807 (only present if ``FPU`` = 1 and ``PULP_XPULP`` = 1)
-
-Reset Value: 0x0000_0000
-
-+-------------+-----------+----------------------------------------------------------------------------------+
-|   Bit #     |  Mode     | Description                                                                      |
-+=============+===========+==================================================================================+
-| 31:5        | RO        | Writes are ignored; reads return 0.                                              |
-+-------------+-----------+----------------------------------------------------------------------------------+
-| 4:0         | RW        | Precision and latency of the iterative Floating-Point div/sqrt unit.             |
-|             |           +-----------------------------------------------------------------------+----------+
-|             |           | Value   | Precision                                                   | Latency  |
-|             |           +---------+-------------------------------------------------------------+----------+
-|             |           | 0       | Default value: single precision                             | 8        |
-|             |           +---------+-------------------------------------------------------------+----------+
-|             |           | 8 - 11  | Computes as many mantissa bits as specified ``fprec`` value | 5        |
-|             |           +---------+-------------------------------------------------------------+----------+
-|             |           | 12 - 15 |                                                             | 6        |
-|             |           +---------+-------------------------------------------------------------+----------+
-|             |           | 16 - 19 |                                                             | 7        |
-|             |           +---------+-------------------------------------------------------------+----------+
-|             |           | 20 - 23 |                                                             | 8        |
-+-------------+-----------+---------+-------------------------------------------------------------+----------+
-
 Privilege Level (``privlv``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -390,7 +357,7 @@ Reset Value: Defined
   +-------------+-----------+----------------------------------------------------------------+
 
 Similar to ``mhartid`` the ``uhartid`` provides the Hardware Thread ID. It differs from ``mhartid`` only in the required privilege level. On
-CV32E40P, as it is a machine mode only implementation, this difference is not noticeable. 
+CV32E40P, as it is a machine mode only implementation, this difference is not noticeable.
 
 Machine Status (``mstatus``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -781,7 +748,7 @@ Since native triggers are not supported, writes to this register from M-Mode wil
    **match**, **m**, **s**, **u**,  **store** and  **load** bitfields of this CSR, which are marked as R/W in Debug Specification
    0.13.2, are therefore implemented as WARL bitfields (corresponding to how these bitfields will be specified in the forthcoming
    Debug Specification 0.14.0).
- 
+
 +-------+----------+------------------------------------------------------------------+
 | Bit#  | Mode     | Description                                                      |
 +=======+==========+==================================================================+

--- a/cores/cv32e40p/user_manual/source/fpu.rst
+++ b/cores/cv32e40p/user_manual/source/fpu.rst
@@ -5,10 +5,13 @@ Floating Point Unit (FPU)
 
 The RV32F ISA extension for floating-point support in the form of IEEE-754 single
 precision can be enabled by setting the parameter **FPU** of the toplevel file
-``cv32e40p_core.sv`` to 1. This will extend the CV32E40P decoder accordingly
-and it will extend the ALU to support the floating-point comparisons and
-classifications. The actual Floating Point Unit is instantiated outside the
+``cv32e40p_core.sv`` to 1. This will extend the CV32E40P decoder accordingly.
+The actual Floating Point Unit (FPU) is instantiated outside the
 CV32E40P and is accessed via the APU interface (see :ref:`apu`).
+The FPU repository used by the CV32E40P core is available at
+https://github.com/pulp-platform/fpnew.
+In the core repository, a wrapper showing how the FPU is connected
+to the core is available at ``example_tb/core/cv32e40p_fp_wrapper.sv``.
 By default a dedicated register file consisting of 32
 floating-point registers, ``f0``-``f31``, is instantiated. This default behavior
 can be overruled by setting the parameter **PULP_ZFINX** of the toplevel
@@ -16,79 +19,9 @@ file ``cv32e40p_core.sv`` to 1, in which case the dedicated register file is
 not included and the general purpose register file is used instead to
 host the floating-point operands.
 
-The latency of the individual instructions and
-information where they are computed are summarized in :numref:`Overview of FP-operations`.
+The latency of the individual instructions are set by means of parameters in the
+FPU repository (see https://github.com/pulp-platform/fpnew/tree/develop/docs).
 
-The FPU is divided into three parts:
-
-1. A *simple FPU* of ~10kGE complexity, which computes FP-ADD, FP-SUB
-   and FP-casts.
-
-2. An *iterative FP-DIV/SQRT unit* of ~7 kGE complexity, which computes
-   FP-DIV/SQRT operations.
-
-3. An *FP-FMA unit* which takes care of all fused operations. This unit
-   is currently only supported through a Synopsys Design Ware
-   instantiation, or a Xilinx block for FPGA targets.
-
-.. table:: Overview of FP-operations
-  :name: Overview of FP-operations
-
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  |   FP-Operation     |   Executed in:     |   Latency     |   Operation                    |   Information                                                                                                               |
-  +====================+====================+===============+================================+=============================================================================================================================+
-  | flw                | LSU                | 2             | Loads 32 to FP-RF              | Mapped to lw                                                                                                                |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fsw                | LSU                | 2             | Stores FP-operand to memory    | Mapped to sw                                                                                                                |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fmadd              | FPU                | 3             | rd = rs1 \* rs2 + rs3          |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fmsub              | FPU                | 3             | rd = rs1 \* rs2– rs3           |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fnmadd             | FPU                | 3             | rd = – (rs1 \* rs2+ rs3)       |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fnmsub             | FPU                | 3             | rd = –(rs1 \* rs2 – rs3)       |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fadd.s             | FPU                | 2             | rd = rs1 + rs2                 |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fsub.s             | FPU                | 2             | rd = rs1 – rs2                 |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fmul.s             | FPU                | 2             | rd = rs1 \* rs2                |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fdiv.s             | FPU                | 5 - 8         | rd = rs1 / rs2                 | According to precision specified in custom :ref:`csr-fprec` CSR to control the precision of FP DIV/SQRT operations          |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fsqrt.s            | FPU                | 5 - 8         | rd = sqrt(rs1)                 |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fclass.s           | ALU                | 1             | See specification              |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fmv.s.w            | ALU                | 1             | Move from int-RF to FP-RF      | Mapped to mv                                                                                                                |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fmv.w.s            | ALU                | 1             | Move from FP-RF to int-RF      |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fsgnj.s            | ALU                | 1             | Inserts sign of rs2            |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fsgnjn.s           | ALU                | 1             | Inserts negative sign of rs2   |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fsgnjx.s           | ALU                | 1             | Inserts xor of the two signs   |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | feq.s              | ALU                | 1             | (rs1 == rs2)                   | Reuses integer comparator                                                                                                   |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | flt.s              | ALU                | 1             | (rs1 < rs2)                    |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fle.s              | ALU                | 1             | (rs1 <= rs2)                   |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fmin               | ALU                | 1             | rd = min(rs1, rs2)             |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fmax               | ALU                | 1             | rd = max(rs1, rs2)             |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fcvt.x.w           | FPU                | 2             | Int to FP cast                 |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fcvt.x.wu          | FPU                | 2             | Unsigned int to FP cast        |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fcvt.w.x           | FPU                | 2             | FP to int cast                 |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-  | fcvt.wu.x          | FPU                | 2             | FP to unsigned int cast        |                                                                                                                             |
-  +--------------------+--------------------+---------------+--------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
 
 FP CSR
 ------
@@ -99,27 +32,8 @@ exceptions that occurred since it was last reset and the rounding mode.
 :ref:`csr-fflags` and :ref:`csr-frm` can be accessed directly or via :ref:`csr-fcsr` which is mapped to
 those two registers.
 
-Since CV32E40P includes an iterative div/sqrt unit, its precision and
-latency can be controlled via the custom :ref:`csr-fprec` CSR. This allows faster
-division / square-root operations at the lower precision. By default,
-the single-precision equivalents are computed with a latency of 8
-cycles. The FPU CSRs are further described in :ref:`cs-registers`.
-
 Floating-point Performance Counters:
 ------------------------------------
 
 Some specific performance counters have been implemented to profile
 FP-kernels.
-
-Some hints on synthesizing the FPU
-----------------------------------
-
-The pipeline of the FPU is not balanced but it includes one pipeline
-register in front of the *simple FPU* which is intended to be moved in
-to the pipeline with automatic retiming commands. The same holds for the
-*FP-FMA unit* which contains two pipeline registers (one in front, and
-one after the unit).
-
-Optimal performance is only achieved with retiming these two blocks.
-This can for example be achieved with the “optimize\_register” command
-of the Synopsys Design Compiler.

--- a/cores/cv32e40p/user_manual/source/fpu.rst
+++ b/cores/cv32e40p/user_manual/source/fpu.rst
@@ -31,9 +31,3 @@ floating-point status and control register (:ref:`csr-fcsr`) which contains the
 exceptions that occurred since it was last reset and the rounding mode.
 :ref:`csr-fflags` and :ref:`csr-frm` can be accessed directly or via :ref:`csr-fcsr` which is mapped to
 those two registers.
-
-Floating-point Performance Counters:
-------------------------------------
-
-Some specific performance counters have been implemented to profile
-FP-kernels.


### PR DESCRIPTION
This PR aims to solve:

#255 

#253 

and it makes updates to the FPU part of the documentation. 

In particular, 

1. It updates the part related to latency and repository of the external FPU
2. It removes the redundat part of the instructions implemented as they are specified in the RISC-V standard (RV32F) 
