### PR TITLE
Attendance record for SW TG meeting of 11 January 2020

### DIFF
--- a/program/TGSoftware_Attendance_2021.md
+++ b/program/TGSoftware_Attendance_2021.md
@@ -1,0 +1,66 @@
+## Software TG Attendance Tracker Template
+
+Only full meetings are shown. Subgroup meetings, joint meetings with other
+groups are excluded.
+
+**Software TG Member Attendance Table**
+
+| Company            |  Person              |21.01.11|21.MM.DD|
+|--------------------|----------------------|:------:|:------:|
+| Alibaba Group      | Yunshai Shang        | Y      |        |
+| Ashling Micro. Ltd | Hugh O'Keeffe        |        |        |
+| Ashling Micro. Ltd | Roisin O'Keeffe      | Y      |        |
+| Ashling Micro. Ltd | Promodkumar CM       | Y      |        |
+| Ashling Micro. Ltd | Rejeesh SB           |        |        |
+| Ashling Micro. Ltd | Vinod appu           |        |        |
+| CMC Microsystems   | Hugh Pollitt-Smith   | Y      |        |
+| Codeplay           | Michael Wong         | Y      |        |
+| Embecosm           | Jeremy Bennett       | Y      |        |
+| Embecosm           | Mary Bennett         |        |        |
+| Embecosm           | Craig Blackmore      |        |        |
+| Embecosm           | Simon Cook           |        |        |
+| Embecosm           | Pietra Ferreira      | Y      |        |
+| Embecosm           | Philipp Krones       | Y      |        |
+| Embecosm           | Jessica Mills        | Y      |        |
+| Embecosm           | Paolo Savini         |        |        |
+| Embecosm           | Shteryana Shopova    | Y      |        |
+| EMUS               | John Martin          |        |        |
+| ETH Zürich         | Robert Balas         |        |        |
+| ETH Zürich         | Björn Forsberg       |        |        |
+| Imperas            | Simon Davidmann      | Y      |        |
+| Futurewei          | Liang Peng           |        |        |
+| Futurewei          | Jingliang (Leo) Wang |        |        |
+| NXP USA, Inc.      | John Waite           |        |        |
+| NXP USA, Inc.      | Jerry Zeng           |        |        |
+| PlatformIO         | Ivan Kravets         | Y      |        |
+| PlatformIO         | Valerii Koval        | Y      |        |
+| Quicklogic         | Tim Saxe             | Y      |        |
+| Silicon Labs. Inc. | Arjan Bink           |        |        |
+| Silicon Labs. Inc. | Paul Zavalney        |        |        |
+| Thales             | Zbigniew Chamski     |        |        |
+| Thales             | Jean-Roch Coulon     |        |        |
+| Thales             | André Sintzoff       | Y      |        |
+| Thales             | Sébastien Jacq       | Y      |        |
+| Univeristy Bologna | Nazareno Bruschi     | Y      |        |
+| Univeristy Bologna | Enrico Tabanelli     | Y      |        |
+| Univeristy Bologna | Giuseppe Tagliavini  | Y      |        |
+
+**Guest/Non-Member Attendance Table**
+
+| Company            |  Person              |21.01.11|21.MM.DD|
+|--------------------|----------------------|:------:|:------:|
+| Eclipse project    | Alexander Fedorov    | Y      |        |
+| Eclipse project    | Frédŕic Desbiens     |        |        |
+| Eclipse project    | Brian King           |        |        |
+| Publitek           | Andrea Barnard       |        |        |
+
+**OpenHW Attendance Table**
+
+| Company            |  Person              |21.01.11|21.MM.DD|
+|--------------------|----------------------|:------:|:------:|
+| OpenHW             | Duncan Bees          | Y      |        |
+| OpenHW             | Rick O'Connor        | Y      |        |
+| OpenHW             | Jim Parisien         |        |        |
+| OpenHW             | Davide Schiavone     |        |        |
+| OpenHW             | Mike Thompson        | Y      |        |
+| OpenHW             | Florian Zaruba       | Y      |        |


### PR DESCRIPTION
	New attendance record started for 2021.

Files changed:

	* program/TGSoftware_Attendance_2021.md: Created.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>