### PR TITLE
Migrate HW task group meeting minutes

### DIFF
--- a/hw/MeetingMinutes/2020-08-06/minutes.md
+++ b/hw/MeetingMinutes/2020-08-06/minutes.md
@@ -1,0 +1,23 @@
+# HW TG August 4 notes:
+
+## Attendees: 
+- Joe Stoy (Bluespec)
+- Charlie Hauck (Bluespec)
+- Davide Schiavone (OpenHW Group)
+- Hugh Pollitt-Smith (CMC Microsystems) 
+- Olive Zhao (CMC Microsystems) 
+- Jeremy Bennett (Embecosm)
+- Jerry Zeng (NXP)
+-  Duncan Bees (OpenHW Group)
+
+## Notes:
+- Bluespec is also implementing the CV32E40P core on an FPGA
+    - First target is VCU118 board but plan to move RISC-V work onto smaller/lower-cost board (Digilent Arty-7, which shares same FPGA as NexysA7)
+    - Plan to port FreeRTOS as well
+    - The intent is to provide a common platform for comparisons of various RISC-V cores
+    - Bluespec and OpenHW Group activities for FPGA porting are parallel but can both benefit from sharing
+- Olive confirmed that the CV32E40P in the pulpissimo platform on the Digilent board is alive and the debugger can connect to it, although the output of the UART is strange (baud rate issue?)
+    - Update: UART output is fine (prints “Hello!”) but processor hangs after first printf
+- It would be good to have an overall project schedule for the activity
+
+

--- a/hw/MeetingMinutes/2020-10-14/minutes.md
+++ b/hw/MeetingMinutes/2020-10-14/minutes.md
@@ -1,0 +1,54 @@
+# Hardware TG: October 14, 2020 Meeting Notes
+
+## Attendees
+- Hugh Pollitt-Smith, CMC Microsystems (Chair)
+- Tim Saxe, Quicklogic (Vice Chair)
+- Duncan Bees, OpenHW Group
+- Rick O'Connor, OpenHW Group
+- Mike Thompson, OpenHW Group
+- Jeremy Bennett, Embecosm
+- Olive Zhao, CMC Microsystems
+- Ary Bhattacharya, University of Southampton
+- John Holden, University of Southampton
+
+## Agenda
+1. Update on CORE-V MCU FPGA platform activities
+2. New Project: CORE-V MCU SoC
+3. University of Southampton research project
+4. Upcoming HW TG meetings
+
+
+## Discussion
+1. Update on CORE-V MCU FPGA platform activities
+    - Add Alexander’s IDE work in the near term activities list; the IDE project is looking to HW TG as a lead customer of the IDE
+        - We will want this working for hardened SOC also
+        - Hugh to touch base with Alexander on next steps
+    - CORE-V toolchain
+        - Based on Quicklogic’s work with the Arnold chip, it would be good to standardize on the CORE-V toolchain (as opposed to PULP), build under a common umbrella
+        - For the upcoming CV32E40P RTL freeze, PULP extensions will not be fully verified; some are exercised, but synthesis/regression flow disables PULP instructions
+            - Goal of the SoC is use the supported features of the toolchain
+        - CORE-V toolchain doesn’t use the PULP instructions currently; needs to be a plan and structured release on which PULP instructions get supported (some PULP extensions have already been made redundant with regular extensions)
+        - CORE-V MCU FPGA platform is currently using the PULP runtime as a simple monitor to compile code and control peripherals; recommendation would be to quit using the runtime and work with FreeRTOS
+            - Need a project to support FreeRTOS for CORE-V and FPGA/SOC platform
+
+2. New Project: CORE-V MCU SoC
+    - Based on Agenda Item 1, it would make sense to switch planned OS support from Zephyr to FreeRTOS
+    - Our intent is to ensure compatibility between FPGA and SOC platforms, make seamless going from the FPGA platform to SoC
+        - Code that runs on the FPGA will still run on the SOC (eFPGA would be invisible in this case)
+    - How does eFPGA meet open source model?
+        - eFPGA is not open source IP that would be contributed to OpenHW Group, and we’re not trying to build open source SoC; once to start to take RTL through the silicon flow, you start adding proprietary IP (tools, libraries, PDKs)
+        - eFPGA provides a means to plug open source IP into a basic structure (CPU, peripherals); our intent is to provide a platform to add/demonstrate open source  IP and differentiation
+        - Other aspects of the ecosystem will be open source (RTL, software toolchain)
+        - We are not planning to provide chips on their own; we want to provide 1000-10000 development boards to seed a healthy developer ecosystem
+
+3. University of Southampton research project
+    - Project is a 10-week group project that is part of a Master’s course; Jeremy/Embecosm is co-supervising group pf 6 students
+    - Project would add RISC-V instruction set extension for Machine Learning on the CV32E40P; intent is to modify the core as opposed to a loosely coupled accelerator
+    - Ary will confirm if they can share their specification document; after project completion, it could be open sourced, but may not be maintained in future
+    - Stretch goals include UVM and FPGA prototyping
+    - This will be a proof-of-concept for a custom vendor extension to the CORE-V toolchain; intent is not to propose extension to RISC-V Foundation, but that would be an aspirational goal 
+    - This is a good illustration of folks taking the IP from OpenHW Group and using it as a starting point to do exploratory work; we don’t yet have a formal way to identify these projects; we also need to recognize the difference between exploratory projects and commercial-grade, volume production cores (big-R/little-d versus little/no-r/big-D); _OpenHW Labs_ —need a release process for fun, speculative research projects, and clear delineation from the production-level development projects 
+
+4. Upcoming meetings
+    - Hugh will put monthly HW TG meetings in the OpenHW calendar for the 3rd Wednesday of each month: November 18, December 16, January 20, February 17, March 17, April 21, May 19
+

--- a/hw/MeetingMinutes/2020-11-18/minutes.md
+++ b/hw/MeetingMinutes/2020-11-18/minutes.md
@@ -1,0 +1,38 @@
+# OpenHW Group HW TG call - November 18, 2020
+
+## Attendees:
+- Hugh Pollitt-Smith
+- Tim Saxe
+- Davide Schiavone
+- Jeremy Bennett
+- Jessical Mills
+- Mel Chaar
+- Michael Wong
+- Mike Thompson
+- Olive Zhao
+
+## Agenda
+1. Update on CORE-V-MCU FPGA
+2. Update on CORE-V-MCU SOC
+3. New university research project: CORE-V-VEC
+
+## Discussion
+
+1. Update on the CORE-V MCU FPGA platform
+    - RTL freeze for CV32E40P is ~1 week away after which updating the FPGA platform with latest RTL would start
+
+2. Update on the CORE-V MCU SOC
+    - Quicklogic is wrangling resources for the project, hopes to have in place by the end of the month
+    - It would be great to have an open source equivalent to ARM CMSIS, which is a HAL for Cortex processors; every peripheral has register maps and can generate documentation and header files
+        - There has been some chatter on this but needs motivation and vested interest ($) to develop
+        - HW/SW TGs may end up defining CMSIS for RISC-V, but need resources to create; need to find someone with a vested interest ($)
+
+3. New research project proposal (CORE-V-VEC)
+    - Word of caution—the vector extension is larger than all the other extensions and the software effort may be quite large; ARM invested 100 engineer years on getting a compiler working
+    - Is the OpenHW Accelerate program connected with RISC-V University Outreach? Jeremy will provide an email intro to Mel Chaar to RISC-V University Outreach, as well as the Southampton group
+- Alexander Fedorov is asking for demo projects for the IDE
+    - Need applications as project templates, linker scripts
+    - FreeRTOS demands something a bit different from the IDE; a bare metal reference/demo is needed
+    - Quicklogic looking at porting a Tensorflow Lite application from Arnold onto CORE-V-MCU
+    - Need a BSP project
+

--- a/hw/MeetingMinutes/2020-12-16/minutes.md
+++ b/hw/MeetingMinutes/2020-12-16/minutes.md
@@ -1,0 +1,44 @@
+# OpenHW Group HW TG Call - December 16, 2020
+
+## Attendees: 
+- Hugh Pollitt-Smith
+- Alfredo Herrera
+- Davide Schiavone
+- Duncan Bees
+- Florian Zaruba
+- Jeremy Bennett
+- Michael Wong
+- Mike Thompson
+- Olive Zhao
+- Rick O’Connor
+
+## Discussion:
+
+- CORE-V-MCU FPGA
+    - Not much test infrastructure from core-v-verif can be reused for verifying the CORE-V-MCU platform
+    - We can make use of tool chain regression tests from SW TG
+    - Alfredo volunteered to help with the SOC test plan
+    - Continuous Integration: we want to automate building the bitstreams and make them more prominent
+        - Have a task running on a build machine that will run nightly regression or after every push to master; will need to launch an instance of Vivado
+        - There will be a stable release and then 
+        - Need to identify a server and also a Vivado license for the Genesys2 build (NexusA7 build can use the free Vivado Webpack version)
+        - CMC is CAD supplier for OpenHW Group and can leverage same servers for CI, but need to resolve Vivado licensing
+        - Florian can drive this effort
+        - In additional to bitstreams, include a video on how to setup the FPGA board
+- CORE-V-MCU SOC
+    - For consistency/clarity, avoid using Arnold2 to reference the CORE-V-MCU SOC platform
+- Future versions of the CORE-V-MCU
+    - IP should be maintained by OpenHW Group, as opposed to Pulpissimo which is maintained by ETH Zurich
+    - Pulpissimo is research-focussed and complicated (e.g., MicroDMA); define a stripped-down architecture that is a demonstrator for the CORE-V cores
+    - Use Pulpissimo for current CORE-V-MCU SOC, but plan to use simpler architecture in future iterations
+    - Florian is working on a minimal specification and will run by Quicklogic
+    - Also need to move away from PULP runtime; again something leaner and more focussed on CORE-V-MCU use cases
+        - FreeRTOS or CMSIS with monitor interface
+        - Don’t want to invent an propriety in-house RTOS
+        - Needs to go through the project process and needs resources
+- First priority is to develop and get agreement on the CORE-V-MCU specification
+    - Document published with OpenHW logo
+    - Florian will write the draft and share with Hugh and Tim; Alfredo has volunteered to review; goal to publish in HW TG in early January
+    - Once the specification is agreed upon, we can develop a roadmap, define incremental deliverables over time
+    - Will need to do for CORE-V-APU as well in future
+


### PR DESCRIPTION
The task group's meeting were previously part of the `core-v-mcu`
repository. Imho we should keep the docs repo technical there.