### PR TITLE
Attendance at SW TG meeting of 8 March 2021

### DIFF
--- a/program/TG Attendance Tracking/TGSoftware_Attendance_2021.md
+++ b/program/TG Attendance Tracking/TGSoftware_Attendance_2021.md
@@ -5,68 +5,71 @@ groups are excluded.
 
 **Software TG Member Attendance Table**
 
-| Company             |  Person               |21.01.11|21.02.08|21.MM.DD|
-|---------------------|-----------------------|:------:|:------:|:------:|
-| aLean-Tec           | Alfredo Herrera       |        | Y      |        |
-| Alibaba Group       | Yunshai Shang         | Y      | Y      |        |
-| Ashling Micro. Ltd  | Hugh O'Keeffe         |        |        |        |
-| Ashling Micro. Ltd  | Roisin O'Keeffe       | Y      | Y      |        |
-| Ashling Micro. Ltd  | Promodkumar CM        | Y      | Y      |        |
-| Ashling Micro. Ltd  | Rejeesh SB            |        |        |        |
-| Ashling Micro. Ltd  | Vinod appu            |        |        |        |
-| CMC Microsystems    | Hugh Pollitt-Smith    | Y      | Y      |        |
-| Codeplay            | Michael Wong          | Y      | Y      |        |
-| Embecosm            | Jeremy Bennett        | Y      | Y      |        |
-| Embecosm            | Mary Bennett          |        |        |        |
-| Embecosm            | Craig Blackmore       |        |        |        |
-| Embecosm            | Simon Cook            |        |        |        |
-| Embecosm            | Pietra Ferreira       | Y      |        |        |
-| Embecosm            | Philipp Krones        | Y      |        |        |
-| Embecosm            | Jessica Mills         | Y      | Y      |        |
-| Embecosm            | Paolo Savini          |        |        |        |
-| Embecosm            | Shteryana Shopova     | Y      | Y      |        |
-| EMUS                | John Martin           |        |        |        |
-| ETH Zürich          | Robert Balas          |        |        |        |
-| ETH Zürich          | Björn Forsberg        |        |        |        |
-| Imperas             | Simon Davidmann       | Y      | Y      |        |
-| Imperas             | Lee Moore             |        | Y      |        |
-| Futurewei           | Liang Peng            |        |        |        |
-| Futurewei           | Jingliang (Leo) Wang  |        |        |        |
-| NXP USA, Inc.       | John Waite            |        |        |        |
-| NXP USA, Inc.       | Jerry Zeng            |        |        |        |
-| PlatformIO          | Ivan Kravets          | Y      | Y      |        |
-| PlatformIO          | Valerii Koval         | Y      | Y      |        |
-| Quicklogic          | Tim Saxe              | Y      |        |        |
-| Silicon Labs. Inc.  | Arjan Bink            |        |        |        |
-| Silicon Labs. Inc.  | Paul Zavalney         |        |        |        |
-| Thales              | Zbigniew Chamski      |        |        |        |
-| Thales              | Anjali Indrapal Gedam |        | Y      |        |
-| Thales              | Jean-Roch Coulon      |        |        |        |
-| Thales              | Subhra Kanti          |        | Y      |        |
-| Thales              | André Sintzoff        | Y      |        |        |
-| Thales              | Sébastien Jacq        | Y      |        |        |
-| Univeristy Bologna  | Nazareno Bruschi      | Y      |        |        |
-| Univeristy Bologna  | Enrico Tabanelli      | Y      | Y      |        |
-| Univeristy Bologna  | Giuseppe Tagliavini   | Y      | Y      |        |
+| Company             |  Person               |21.01.11|21.02.08|21.03.08|21.MM.DD|
+|---------------------|-----------------------|:------:|:------:|:------:|:------:|
+| aLean-Tec           | Alfredo Herrera       |        | Y      |        |        |
+| Alibaba Group       | Yunshai Shang         | Y      | Y      | Y      |        |
+| Ashling Micro. Ltd  | Hugh O'Keeffe         |        |        |        |        |
+| Ashling Micro. Ltd  | Roisin O'Keeffe       | Y      | Y      | Y      |        |
+| Ashling Micro. Ltd  | Promodkumar CM        | Y      | Y      | Y      |        |
+| Ashling Micro. Ltd  | Rejeesh SB            |        |        |        |        |
+| Ashling Micro. Ltd  | Vinod appu            |        |        |        |        |
+| CMC Microsystems    | Hugh Pollitt-Smith    | Y      | Y      | Y      |        |
+| CMC Microsystems    | Olive Zhao            |        |        | Y      |        |
+| Codeplay            | Michael Wong          | Y      | Y      | Y      |        |
+| Embecosm            | Jeremy Bennett        | Y      | Y      | Y      |        |
+| Embecosm            | Mary Bennett          |        |        |        |        |
+| Embecosm            | Craig Blackmore       |        |        |        |        |
+| Embecosm            | Simon Cook            |        |        |        |        |
+| Embecosm            | Pietra Ferreira       | Y      |        |        |        |
+| Embecosm            | Philipp Krones        | Y      |        | Y      |        |
+| Embecosm            | Jessica Mills         | Y      | Y      | Y      |        |
+| Embecosm            | Paolo Savini          |        |        |        |        |
+| Embecosm            | Shteryana Shopova     | Y      | Y      | Y      |        |
+| EMUS                | John Martin           |        |        |        |        |
+| ETH Zürich          | Robert Balas          |        |        | Y      |        |
+| ETH Zürich          | Björn Forsberg        |        |        |        |        |
+| Imperas             | Simon Davidmann       | Y      | Y      | Y      |        |
+| Imperas             | Kevin McDermott       |        |        | Y      |        |
+| Imperas             | Lee Moore             |        | Y      |        |        |
+| Futurewei           | Liang Peng            |        |        |        |        |
+| Futurewei           | Jingliang (Leo) Wang  |        |        |        |        |
+| NXP USA, Inc.       | John Waite            |        |        |        |        |
+| NXP USA, Inc.       | Jerry Zeng            |        |        |        |        |
+| PlatformIO          | Ivan Kravets          | Y      | Y      | Y      |        |
+| PlatformIO          | Valerii Koval         | Y      | Y      | Y      |        |
+| Quicklogic          | Tim Saxe              | Y      |        | Y      |        |
+| Silicon Labs. Inc.  | Arjan Bink            |        |        |        |        |
+| Silicon Labs. Inc.  | Paul Zavalney         |        |        |        |        |
+| Thales              | Zbigniew Chamski      |        |        |        |        |
+| Thales              | Anjali Indrapal Gedam |        | Y      | Y      |        |
+| Thales              | Jean-Roch Coulon      |        |        |        |        |
+| Thales              | Sébastien Jacq        | Y      |        |        |        |
+| Thales              | Subhra Kanti          |        | Y      |        |        |
+| Thales              | André Sintzoff        | Y      |        |        |        |
+| Thales              | Zbigniew Chamski      |        |        | Y      |        |
+| Univeristy Bologna  | Nazareno Bruschi      | Y      |        | Y      |        |
+| Univeristy Bologna  | Gianmarco Ottavi      |        |        | Y      |        |
+| Univeristy Bologna  | Enrico Tabanelli      | Y      | Y      |        |        |
+| Univeristy Bologna  | Giuseppe Tagliavini   | Y      | Y      | Y      |        |
 
 **Guest/Non-Member Attendance Table**
 
-| Company             |  Person               |21.01.11|21.02.08|21.MM.DD|
-|---------------------|-----------------------|:------:|:------:|:------:|
-| Eclipse project     | Alexander Fedorov     | Y      | Y      |        |
-| Eclipse project     | Frédŕic Desbiens      |        |        |        |
-| Eclipse project     | Brian King            |        | Y      |        |
-| Publitek            | Andrea Barnard        |        |        |        |
-| University Tübingen | Christoph Gerum       |        | Y      |        |
-| University Tübingen | Serkan Muhcu          |        | Y      |        |
+| Company             |  Person               |21.01.11|21.02.08|21.03.08|21.MM.DD|
+|---------------------|-----------------------|:------:|:------:|:------:|:------:|
+| Eclipse project     | Alexander Fedorov     | Y      | Y      | Y      |        |
+| Eclipse project     | Frédŕic Desbiens      |        |        | Y      |        |
+| Eclipse project     | Brian King            |        | Y      |        |        |
+| Publitek            | Andrea Barnard        |        |        |        |        |
+| University Tübingen | Christoph Gerum       |        | Y      |        |        |
+| University Tübingen | Serkan Muhcu          |        | Y      |        |        |
 
 **OpenHW Attendance Table**
 
-| Company             |  Person               |21.01.11|21.02.08|21.MM.DD|
-|---------------------|-----------------------|:------:|:------:|:------:|
-| OpenHW              | Duncan Bees           | Y      | Y      |        |
-| OpenHW              | Rick O'Connor         | Y      | Y      |        |
-| OpenHW              | Jim Parisien          |        |        |        |
-| OpenHW              | Davide Schiavone      |        |        |        |
-| OpenHW              | Mike Thompson         | Y      |        |        |
-| OpenHW              | Florian Zaruba        | Y      |        |        |
+| Company             |  Person               |21.01.11|21.02.08|21.03.08|21.MM.DD|
+|---------------------|-----------------------|:------:|:------:|:------:|:------:|
+| OpenHW              | Duncan Bees           | Y      | Y      | Y      |        |
+| OpenHW              | Rick O'Connor         | Y      | Y      | Y      |        |
+| OpenHW              | Davide Schiavone      |        |        |        |        |
+| OpenHW              | Mike Thompson         | Y      |        | Y      |        |
+| OpenHW              | Florian Zaruba        | Y      |        | Y      |        |


### PR DESCRIPTION
Files changed:

	* program/TG Attendance Tracking/TGSoftware_Attendance_2021.md:
	Add attendance from meeting of 8 March 2021.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>