### PR TITLE
Attendance at SW TG meeting 21 June 2021

### DIFF
--- a/program/TWG and TG Attendance Tracking/TGSoftware_Attendance_2021.md
+++ b/program/TWG and TG Attendance Tracking/TGSoftware_Attendance_2021.md
@@ -5,73 +5,74 @@ groups are excluded.
 
 **Software TG Member Attendance Table**
 
-| Company             |  Person               |21.01.11|21.02.08|21.03.08|21.04.12|21.05.10|21.MM.DD|
-|---------------------|-----------------------|:------:|:------:|:------:|:------:|:------:|:------:|
-| aLean-Tec           | Alfredo Herrera       |        | Y      |        |        |        |        |
-| Alibaba Group       | David Chen            |        |        |        |        | Y      |        |
-| Alibaba Group       | Vincent Chu           |        |        |        |        | Y      |        |
-| Alibaba Group       | Yunhai Shang          | Y      | Y      | Y      | Y      | Y      |        |
-| Ashling Micro. Ltd  | Roisin O'Keeffe       | Y      | Y      | Y      | Y      |        |        |
-| Ashling Micro. Ltd  | Promodkumar CM        | Y      | Y      | Y      | Y      |        |        |
-| Ashling Micro. Ltd  | Rejeesh SB            |        |        |        |        |        |        |
-| Ashling Micro. Ltd  | Vinod appu            |        |        |        |        |        |        |
-| CMC Microsystems    | Hugh Pollitt-Smith    | Y      | Y      | Y      | Y      | Y      |        |
-| CMC Microsystems    | Olive Zhao            |        |        | Y      | Y      | Y      |        |
-| Codeplay            | Michael Wong          | Y      | Y      | Y      |        | Y      |        |
-| Embecosm            | Jeremy Bennett        | Y      | Y      | Y      | Y      | Y      |        |
-| Embecosm            | Mary Bennett          |        |        |        |        |        |        |
-| Embecosm            | Craig Blackmore       |        |        |        |        |        |        |
-| Embecosm            | Simon Cook            |        |        |        |        |        |        |
-| Embecosm            | Pietra Ferreira       | Y      |        |        | Y      | Y      |        |
-| Embecosm            | Ed Jones              |        |        |        |        | Y      |        |
-| Embecosm            | Philipp Krones        | Y      |        | Y      | Y      | Y      |        |
-| Embecosm            | Jessica Mills         | Y      | Y      | Y      |        |        |        |
-| Embecosm            | Paolo Savini          |        |        |        |        |        |        |
-| Embecosm            | Shteryana Shopova     | Y      | Y      | Y      | Y      | Y      |        |
-| EMUS                | John Martin           |        |        |        |        |        |        |
-| ETH Zürich          | Robert Balas          |        |        | Y      | Y      |        |        |
-| ETH Zürich          | Björn Forsberg        |        |        |        |        |        |        |
-| Imperas             | Simon Davidmann       | Y      | Y      | Y      | Y      |        |        |
-| Imperas             | Kevin McDermott       |        |        | Y      |        |        |        |
-| Imperas             | Lee Moore             |        | Y      |        |        |        |        |
-| Futurewei           | Liang Peng            |        |        |        |        |        |        |
-| Futurewei           | Jingliang (Leo) Wang  |        |        |        |        |        |        |
-| NXP USA, Inc.       | John Waite            |        |        |        |        |        |        |
-| NXP USA, Inc.       | Jerry Zeng            |        |        |        |        |        |        |
-| PlatformIO          | Ivan Kravets          | Y      | Y      | Y      | Y      | Y      |        |
-| PlatformIO          | Valerii Koval         | Y      | Y      | Y      | Y      | Y      |        |
-| Quicklogic          | Tim Saxe              | Y      |        | Y      | Y      | Y      |        |
-| Silicon Labs. Inc.  | Arjan Bink            |        |        |        |        |        |        |
-| Silicon Labs. Inc.  | Paul Zavalney         |        |        |        |        |        |        |
-| Thales              | Zbigniew Chamski      |        |        |        |        | Y      |        |
-| Thales              | Anjali Indrapal Gedam |        | Y      | Y      | Y      | Y      |        |
-| Thales              | Jean-Roch Coulon      |        |        |        |        |        |        |
-| Thales              | Sébastien Jacq        | Y      |        |        |        | Y      |        |
-| Thales              | Subhra Kanti          |        | Y      |        |        |        |        |
-| Thales              | André Sintzoff        | Y      |        |        | Y      |        |        |
-| Thales              | Zbigniew Chamski      |        |        | Y      | Y      |        |        |
-| Univeristy Bologna  | Nazareno Bruschi      | Y      |        | Y      |        | Y      |        |
-| Univeristy Bologna  | Gianmarco Ottavi      |        |        | Y      |        | Y      |        |
-| Univeristy Bologna  | Enrico Tabanelli      | Y      | Y      |        |        | Y      |        |
-| Univeristy Bologna  | Giuseppe Tagliavini   | Y      | Y      | Y      | Y      | Y      |        |
+| Company             |  Person               |21.01.11|21.02.08|21.03.08|21.04.12|21.05.10|21.06.14|21.06.21|21.MM.DD|
+|---------------------|-----------------------|:------:|:------:|:------:|:------:|:------:|:------:|:------:|:------:|
+| aLean-Tec           | Alfredo Herrera       |        | Y      |        |        |        |        |        |        |
+| Alibaba Group       | David Chen            |        |        |        |        | Y      |        |        |        |
+| Alibaba Group       | Vincent Chu           |        |        |        |        | Y      |        | Y      |        |
+| Alibaba Group       | Yunhai Shang          | Y      | Y      | Y      | Y      | Y      |        | Y      |        |
+| Amazon              | Richard Barry         |        |        |        |        |        |        | Y      |        |
+| Ashling Micro. Ltd  | Roisin O'Keeffe       | Y      | Y      | Y      | Y      |        |        |        |        |
+| Ashling Micro. Ltd  | Promodkumar CM        | Y      | Y      | Y      | Y      |        |        |        |        |
+| Ashling Micro. Ltd  | Rejeesh SB            |        |        |        |        |        |        |        |        |
+| Ashling Micro. Ltd  | Vinod appu            |        |        |        |        |        |        |        |        |
+| CMC Microsystems    | Hugh Pollitt-Smith    | Y      | Y      | Y      | Y      | Y      |        |        |        |
+| CMC Microsystems    | Olive Zhao            |        |        | Y      | Y      | Y      |        | Y      |        |
+| Codeplay            | Michael Wong          | Y      | Y      | Y      |        | Y      |        |        |        |
+| Embecosm            | Jeremy Bennett        | Y      | Y      | Y      | Y      | Y      |        | Y      |        |
+| Embecosm            | Mary Bennett          |        |        |        |        |        |        |        |        |
+| Embecosm            | Craig Blackmore       |        |        |        |        |        |        |        |        |
+| Embecosm            | Simon Cook            |        |        |        |        |        |        |        |        |
+| Embecosm            | Pietra Ferreira       | Y      |        |        | Y      | Y      |        |        |        |
+| Embecosm            | Ed Jones              |        |        |        |        | Y      |        |        |        |
+| Embecosm            | Philipp Krones        | Y      |        | Y      | Y      | Y      |        |        |        |
+| Embecosm            | Jessica Mills         | Y      | Y      | Y      |        |        |        | Y      |        |
+| Embecosm            | Paolo Savini          |        |        |        |        |        |        |        |        |
+| Embecosm            | Shteryana Shopova     | Y      | Y      | Y      | Y      | Y      |        |        |        |
+| EMUS                | John Martin           |        |        |        |        |        |        |        |        |
+| ETH Zürich          | Robert Balas          |        |        | Y      | Y      |        |        |        |        |
+| ETH Zürich          | Björn Forsberg        |        |        |        |        |        |        |        |        |
+| Imperas             | Simon Davidmann       | Y      | Y      | Y      | Y      |        |        | Y      |        |
+| Imperas             | Kevin McDermott       |        |        | Y      |        |        |        |        |        |
+| Imperas             | Lee Moore             |        | Y      |        |        |        |        |        |        |
+| Futurewei           | Liang Peng            |        |        |        |        |        |        |        |        |
+| Futurewei           | Jingliang (Leo) Wang  |        |        |        |        |        |        |        |        |
+| NXP USA, Inc.       | John Waite            |        |        |        |        |        |        |        |        |
+| NXP USA, Inc.       | Jerry Zeng            |        |        |        |        |        |        |        |        |
+| PlatformIO          | Ivan Kravets          | Y      | Y      | Y      | Y      | Y      |        |        |        |
+| PlatformIO          | Valerii Koval         | Y      | Y      | Y      | Y      | Y      |        |        |        |
+| Quicklogic          | Tim Saxe              | Y      |        | Y      | Y      | Y      |        |        |        |
+| Silicon Labs. Inc.  | Arjan Bink            |        |        |        |        |        |        |        |        |
+| Silicon Labs. Inc.  | Paul Zavalney         |        |        |        |        |        |        |        |        |
+| Thales              | Zbigniew Chamski      |        |        |        |        | Y      |        |        |        |
+| Thales              | Anjali Indrapal Gedam |        | Y      | Y      | Y      | Y      |        |        |        |
+| Thales              | Jean-Roch Coulon      |        |        |        |        |        |        |        |        |
+| Thales              | Sébastien Jacq        | Y      |        |        |        | Y      |        |        |        |
+| Thales              | Subhra Kanti          |        | Y      |        |        |        |        |        |        |
+| Thales              | André Sintzoff        | Y      |        |        | Y      |        |        |        |        |
+| Thales              | Zbigniew Chamski      |        |        | Y      | Y      |        |        |        |        |
+| Univeristy Bologna  | Nazareno Bruschi      | Y      |        | Y      |        | Y      |        |        |        |
+| Univeristy Bologna  | Gianmarco Ottavi      |        |        | Y      |        | Y      |        |        |        |
+| Univeristy Bologna  | Enrico Tabanelli      | Y      | Y      |        |        | Y      |        |        |        |
+| Univeristy Bologna  | Giuseppe Tagliavini   | Y      | Y      | Y      | Y      | Y      |        |        |        |
 
 **Guest/Non-Member Attendance Table**
 
-| Company             |  Person               |21.01.11|21.02.08|21.03.08|21.04.12|21.05.10|21.MM.DD|
-|---------------------|-----------------------|:------:|:------:|:------:|:------:|:------:|:------:|
-| Eclipse project     | Alexander Fedorov     | Y      | Y      | Y      | Y      |        |        |
-| Eclipse project     | Frédŕic Desbiens      |        |        | Y      | Y      |        |        |
-| Eclipse project     | Brian King            |        | Y      |        |        |        |        |
-| Publitek            | Andrea Barnard        |        |        |        |        |        |        |
-| University Tübingen | Christoph Gerum       |        | Y      |        |        |        |        |
-| University Tübingen | Serkan Muhcu          |        | Y      |        |        |        |        |
+| Company             |  Person               |21.01.11|21.02.08|21.03.08|21.04.12|21.05.10|21.06.14|21.06.21|21.MM.DD|
+|---------------------|-----------------------|:------:|:------:|:------:|:------:|:------:|:------:|:------:|:------:|
+| Eclipse project     | Alexander Fedorov     | Y      | Y      | Y      | Y      |        |        |        |        |
+| Eclipse project     | Frédŕic Desbiens      |        |        | Y      | Y      |        |        |        |        |
+| Eclipse project     | Brian King            |        | Y      |        |        |        |        |        |        |
+| Publitek            | Andrea Barnard        |        |        |        |        |        |        |        |        |
+| University Tübingen | Christoph Gerum       |        | Y      |        |        |        |        |        |        |
+| University Tübingen | Serkan Muhcu          |        | Y      |        |        |        |        |        |        |
 
 **OpenHW Attendance Table**
 
-| Company             |  Person               |21.01.11|21.02.08|21.03.08|21.04.12|21.05.10|21.MM.DD|
-|---------------------|-----------------------|:------:|:------:|:------:|:------:|:------:|:------:|
-| OpenHW              | Duncan Bees           | Y      | Y      | Y      | Y      | Y      |        |
-| OpenHW              | Rick O'Connor         | Y      | Y      | Y      | Y      | Y      |        |
-| OpenHW              | Davide Schiavone      |        |        |        |        |        |        |
-| OpenHW              | Mike Thompson         | Y      |        | Y      | Y      | Y      |        |
-| OpenHW              | Florian Zaruba        | Y      |        | Y      | Y      | Y      |        |
+| Company             |  Person               |21.01.11|21.02.08|21.03.08|21.04.12|21.05.10|21.06.14|21.06.21|21.MM.DD|
+|---------------------|-----------------------|:------:|:------:|:------:|:------:|:------:|:------:|:------:|:------:|
+| OpenHW              | Duncan Bees           | Y      | Y      | Y      | Y      | Y      |        | Y      |        |
+| OpenHW              | Rick O'Connor         | Y      | Y      | Y      | Y      | Y      |        | Y      |        |
+| OpenHW              | Davide Schiavone      |        |        |        |        |        |        |        |        |
+| OpenHW              | Mike Thompson         | Y      |        | Y      | Y      | Y      |        |        |        |
+| OpenHW              | Florian Zaruba        | Y      |        | Y      | Y      | Y      |        | Y      |        |


### PR DESCRIPTION
Files changed in program/TWG and TG Attendance Tracking:

	* /TGSoftware_Attendance_2021.md: Add blank column for 14 June
	2021 and add attendance for 21 June 2021.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>