### PR TITLE
Correct Softwware TG report for July 2021.

### DIFF
--- a/program/TG-reports-for-TWG/2021/20210726-sw-tg.md
+++ b/program/TG-reports-for-TWG/2021/20210726-sw-tg.md
@@ -86,7 +86,7 @@ Links to reports on four Software TG projects and one joint Software/Hardware TG
 
 * [Verilator modeling report to Software TG](https://github.com/openhwgroup/core-v-docs/blob/master/hw/projects/verilator-model/2021/20210712-report.md) and [Verilator modeling report to Hardware TG](https://github.com/openhwgroup/core-v-docs/blob/master/hw/projects/verilator-model/2021/202100721-report.md).  Note that this is Hardware TG led project, so this is only a report on the software component.
 
-  - At Project Concept stage.
+  - At Project Launch stage.
   - This month:
 
     - [project plan and risk register](https://docs.google.com/spreadsheets/d/1Sl_GIklam3redWNj_DRVRVVBD49LvLD8k1zeFsJXllc) updated;


### PR DESCRIPTION
Files changed:

	* program/TG-reports-for-TWG/2021/20210726-sw-tg.md: Record
	Verilator modeling project as being at Project Launch stage.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>