### PR TITLE
Attendance at Software TG meeting 10 January 2022.

### DIFF
--- a/program/TWG and TG Attendance Tracking/TGSoftware_Attendance_2022.md
+++ b/program/TWG and TG Attendance Tracking/TGSoftware_Attendance_2022.md
@@ -1,0 +1,67 @@
+# Software TG Attendance Tracker 2022
+
+Only full meetings are shown. Subgroup meetings, joint meetings with other
+groups are excluded.
+
+**Software TG Member Attendance Table**
+
+| Company                |  Person               |22.01.10|22.MM.DD|
+|------------------------|-----------------------|:------:|:------:|
+| Alibaba Group          | David Chen            |        |        |
+| Alibaba Group          | Vincent Chu           |        |        |
+| Alibaba Group          | Yunhai Shang          |        |        |
+| Amazon                 | Richard Barry         | Y      |        |
+| Ashling Micro. Ltd     | Hugh O'Keeffe         | Y      |        |
+| Ashling Micro. Ltd     | Promodkumar CM        |        |        |
+| Ashling Micro. Ltd     | Rejeesh SB            |        |        |
+| CAS PLCT Lab           | Jiawei                |        |        |
+| CAS PLCT Lab           | Liao Shihua           |        |        |
+| CAS PLCT Lab           | Wei Wu                |        |        |
+| CMC Microsystems       | Hugh Pollitt-Smith    | Y      |        |
+| CMC Microsystems       | Olive Zhao            |        |        |
+| Codeplay               | Michael Wong          |        |        |
+| Embecosm               | Jeremy Bennett        | Y      |        |
+| Embecosm               | Maxim Blinov          | Y      |        |
+| Embecosm               | Philipp Krones        | Y      |        |
+| Embecosm               | Shteryana Shopova     | Y      |        |
+| EMUS                   | John Martin           |        |        |
+| ETH Zürich             | Robert Balas          | Y      |        |
+| Imperas                | Simon Davidmann       |        |        |
+| Imperas                | Kevin McDermott       |        |        |
+| Imperas                | Lee Moore             |        |        |
+| Futurewei              | Jingliang (Leo) Wang  |        |        |
+| NXP USA, Inc.          | Jerry Zeng            |        |        |
+| Quicklogic             | Greg Martin           |        |        |
+| Quicklogic             | Tim Saxe              |        |        |
+| Silicon Labs. Inc.     | Arjan Bink            |        |        |
+| Thales                 | Zbigniew Chamski      |        |        |
+| Thales                 | Anjali Indrapal Gedam |        |        |
+| Thales                 | Jean-Roch Coulon      |        |        |
+| Thales                 | Sébastien Jacq        |        |        |
+| Thales                 | André Sintzoff        |        |        |
+| Thales                 | Zbigniew Chamski      |        |        |
+| Univeristy Bologna     | Nazareno Bruschi      | Y      |        |
+| Univeristy Bologna     | Gianmarco Ottavi      |        |        |
+| Univeristy Bologna     | Enrico Tabanelli      | Y      |        |
+| Univeristy Bologna     | Giuseppe Tagliavini   |        |        |
+
+**Guest/Non-Member Attendance Table**
+
+| Company                |  Person               |22.01.10|22.MM.DD|
+|------------------------|-----------------------|:------:|:------:|
+| Eclipse project        | Alexander Fedorov     | Y      |        |
+| Eclipse project        | Frédŕic Desbiens      |        |        |
+| Eclipse project        | Brian King            |        |        |
+| Publitek               | Andrea Barnard        |        |        |
+| University Tübingen    | Christoph Gerum       |        |        |
+| University Tübingen    | Serkan Muhcu          |        |        |
+
+**OpenHW Attendance Table**
+
+| Company                |  Person               |22.01.10|22.MM.DD|
+|------------------------|-----------------------|:------:|:------:|
+| OpenHW                 | Duncan Bees           | Y      |        |
+| OpenHW                 | Rick O'Connor         | Y      |        |
+| OpenHW                 | Davide Schiavone      |        |        |
+| OpenHW                 | Mike Thompson         |        |        |
+| OpenHW                 | Florian Zaruba        |        |        |


### PR DESCRIPTION
Files changed in program/TWG and TG Attendance Tracking:

	* TGSoftware_Attendance_2022.md: Created.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>