### PR TITLE
Attendance at Software TG meeting of 9 May 2022.

### DIFF
--- a/program/TWG-and-TG-Attendance-Tracking/TGSoftware_Attendance_2022.md
+++ b/program/TWG-and-TG-Attendance-Tracking/TGSoftware_Attendance_2022.md
@@ -5,66 +5,68 @@ groups are excluded.
 
 **Software TG Member Attendance Table**
 
-| Company                |  Person               |22.04.11|22.03.14|22.02.14|22.01.10|22.MM.DD|
-|------------------------|-----------------------|:------:|:------:|:------:|:------:|:------:|
-| Alibaba Group          | David Chen            |        |        |        |        |        |
-| Alibaba Group          | Vincent Chu           |        |        |        |        |        |
-| Alibaba Group          | Yunhai Shang          |        |        |        |        |        |
-| Amazon                   Joseph Julicher       |        | Y      |        |        |        |
-| Amazon                 | Richard Barry         |        | Y      | Y      | Y      |        |
-| Ashling Micro. Ltd     | Hugh O'Keeffe         | Y      |        | Y      | Y      |        |
-| Ashling Micro. Ltd     | Promodkumar CM        | Y      | Y      | Y      |        |        |
-| Ashling Micro. Ltd     | Rejeesh SB            |        | Y      |        |        |        |
-| CAS PLCT Lab           | Qihan Cai             |        |        | Y      |        |        |
-| CAS PLCT Lab           | Jiawei Chen           |        |        |        |        |        |
-| CAS PLCT Lab           | Liao Shihua           |        |        |        |        |        |
-| CAS PLCT Lab           | Wei Wu                |        |        |        |        |        |
-| CAS PLCT Lab           | Wu Xinlong            | Y      |        |        |        |        |
-| CMC Microsystems       | Hugh Pollitt-Smith    | Y      |        | Y      | Y      |        |
-| CMC Microsystems       | Olive Zhao            | Y      | Y      | Y      |        |        |
-| Codeplay               | Michael Wong          |        |        |        |        |        |
-| Embecosm               | Jeremy Bennett        | Y      | Y      | Y      | Y      |        |
-| Embecosm               | Maxim Blinov          | Y      | Y      | Y      | Y      |        |
-| Embecosm               | Philipp Krones        |        |        |        | Y      |        |
-| Embecosm               | Shteryana Shopova     | Y      | Y      | Y      | Y      |        |
-| EMUS                   | John Martin           |        |        |        |        |        |
-| ETH Zürich             | Robert Balas          | Y      |        |        | Y      |        |
-| Imperas                | Simon Davidmann       |        |        |        |        |        |
-| Imperas                | Kevin McDermott       |        |        |        |        |        |
-| Imperas                | Lee Moore             |        |        |        |        |        |
-| Futurewei              | Jingliang (Leo) Wang  |        |        |        |        |        |
-| NXP USA, Inc.          | Jerry Zeng            |        |        |        |        |        |
-| Quicklogic             | Greg Martin           |        |        |        |        |        |
-| Quicklogic             | Tim Saxe              |        |        |        |        |        |
-| Silicon Labs. Inc.     | Arjan Bink            | Y      |        |        |        |        |
-| Thales                 | Zbigniew Chamski      |        |        |        |        |        |
-| Thales                 | Anjali Indrapal Gedam |        |        |        |        |        |
-| Thales                 | Jean-Roch Coulon      |        |        |        |        |        |
-| Thales                 | Sébastien Jacq        |        |        |        |        |        |
-| Thales                 | André Sintzoff        |        |        |        |        |        |
-| Thales                 | Zbigniew Chamski      |        |        |        |        |        |
-| Univeristy Bologna     | Nazareno Bruschi      |        | Y      |        | Y      |        |
-| Univeristy Bologna     | Gianmarco Ottavi      |        |        |        |        |        |
-| Univeristy Bologna     | Enrico Tabanelli      |        | Y      | Y      | Y      |        |
-| Univeristy Bologna     | Giuseppe Tagliavini   |        |        |        |        |        |
+| Company                |  Person               |22.05.09|22.04.11|22.03.14|22.02.14|22.01.10|22.MM.DD|
+|------------------------|-----------------------|:------:|:------:|:------:|:------:|:------:|:------:|
+| Alibaba Group          | David Chen            |        |        |        |        |        |        |
+| Alibaba Group          | Vincent Chu           |        |        |        |        |        |        |
+| Alibaba Group          | Yunhai Shang          | Y      |        |        |        |        |        |
+| Amazon                 | Joseph Julicher       |        |        | Y      |        |        |        |
+| Amazon                 | Richard Barry         | Y      |        | Y      | Y      | Y      |        |
+| Ashling Micro. Ltd     | Hugh O'Keeffe         | Y      | Y      |        | Y      | Y      |        |
+| Ashling Micro. Ltd     | Promodkumar CM        | Y      | Y      | Y      | Y      |        |        |
+| Ashling Micro. Ltd     | Rejeesh SB            |        |        | Y      |        |        |        |
+| CAS PLCT Lab           | Qihan Cai             |        |        |        | Y      |        |        |
+| CAS PLCT Lab           | Jiawei Chen           |        |        |        |        |        |        |
+| CAS PLCT Lab           | Yulong Shi            | Y      |        |        |        |        |        |
+| CAS PLCT Lab           | Liao Shihua           | Y      |        |        |        |        |        |
+| CAS PLCT Lab           | Weiwei Li             | Y      |        |        |        |        |        |
+| CAS PLCT Lab           | Wei Wu                |        |        |        |        |        |        |
+| CAS PLCT Lab           | Wu Xinlong            |        | Y      |        |        |        |        |
+| CMC Microsystems       | Hugh Pollitt-Smith    |        | Y      |        | Y      | Y      |        |
+| CMC Microsystems       | Olive Zhao            | Y      | Y      | Y      | Y      |        |        |
+| Codeplay               | Michael Wong          |        |        |        |        |        |        |
+| Embecosm               | Jeremy Bennett        | Y      | Y      | Y      | Y      | Y      |        |
+| Embecosm               | Maxim Blinov          | Y      | Y      | Y      | Y      | Y      |        |
+| Embecosm               | Philipp Krones        |        |        |        |        | Y      |        |
+| Embecosm               | Shteryana Shopova     | Y      | Y      | Y      | Y      | Y      |        |
+| EMUS                   | John Martin           |        |        |        |        |        |        |
+| ETH Zürich             | Robert Balas          | Y      | Y      |        |        | Y      |        |
+| Imperas                | Simon Davidmann       |        |        |        |        |        |        |
+| Imperas                | Kevin McDermott       |        |        |        |        |        |        |
+| Imperas                | Lee Moore             |        |        |        |        |        |        |
+| Futurewei              | Jingliang (Leo) Wang  |        |        |        |        |        |        |
+| NXP USA, Inc.          | Jerry Zeng            |        |        |        |        |        |        |
+| Quicklogic             | Greg Martin           |        |        |        |        |        |        |
+| Quicklogic             | Tim Saxe              |        |        |        |        |        |        |
+| Silicon Labs. Inc.     | Arjan Bink            |        | Y      |        |        |        |        |
+| Thales                 | Zbigniew Chamski      |        |        |        |        |        |        |
+| Thales                 | Anjali Indrapal Gedam |        |        |        |        |        |        |
+| Thales                 | Jean-Roch Coulon      |        |        |        |        |        |        |
+| Thales                 | Sébastien Jacq        |        |        |        |        |        |        |
+| Thales                 | André Sintzoff        |        |        |        |        |        |        |
+| Thales                 | Zbigniew Chamski      |        |        |        |        |        |        |
+| Univeristy Bologna     | Nazareno Bruschi      |        |        | Y      |        | Y      |        |
+| Univeristy Bologna     | Gianmarco Ottavi      |        |        |        |        |        |        |
+| Univeristy Bologna     | Enrico Tabanelli      |        |        | Y      | Y      | Y      |        |
+| Univeristy Bologna     | Giuseppe Tagliavini   |        |        |        |        |        |        |
 
 **Guest/Non-Member Attendance Table**
 
-| Company                |  Person               |22.04.11|22.03.14|22.02.14|22.01.10|22.MM.DD|
-|------------------------|-----------------------|:------:|:------:|:------:|:------:|:------:|
-| Eclipse project        | Alexander Fedorov     |        |        | Y      | Y      |        |
-| Eclipse project        | Frédŕic Desbiens      |        |        |        |        |        |
-| Eclipse project        | Brian King            |        |        |        |        |        |
-| Publitek               | Andrea Barnard        |        |        |        |        |        |
-| University Tübingen    | Christoph Gerum       |        |        |        |        |        |
-| University Tübingen    | Serkan Muhcu          |        |        |        |        |        |
+| Company                |  Person               |22.05.09|22.04.11|22.03.14|22.02.14|22.01.10|22.MM.DD|
+|------------------------|-----------------------|:------:|:------:|:------:|:------:|:------:|:------:|
+| Eclipse project        | Alexander Fedorov     |        |        |        | Y      | Y      |        |
+| Eclipse project        | Frédŕic Desbiens      |        |        |        |        |        |        |
+| Eclipse project        | Brian King            |        |        |        |        |        |        |
+| Publitek               | Andrea Barnard        |        |        |        |        |        |        |
+| University Tübingen    | Christoph Gerum       |        |        |        |        |        |        |
+| University Tübingen    | Serkan Muhcu          |        |        |        |        |        |        |
 
 **OpenHW Attendance Table**
 
-| Company                |  Person               |22.04.11|22.03.14|22.02.14|22.01.10|22.MM.DD|
-|------------------------|-----------------------|:------:|:------:|:------:|:------:|:------:|
-| OpenHW                 | Duncan Bees           | Y      | Y      | Y      | Y      |        |
-| OpenHW                 | Rick O'Connor         | Y      |        | Y      | Y      |        |
-| OpenHW                 | Davide Schiavone      |        |        |        |        |        |
-| OpenHW                 | Mike Thompson         | Y      | Y      |        |        |        |
-| OpenHW                 | Florian Zaruba        | Y      | Y      | Y      |        |        |
+| Company                |  Person               |22.05.09|22.04.11|22.03.14|22.02.14|22.01.10|22.MM.DD|
+|------------------------|-----------------------|:------:|:------:|:------:|:------:|:------:|:------:|
+| OpenHW                 | Duncan Bees           | Y      | Y      | Y      | Y      | Y      |        |
+| OpenHW                 | Rick O'Connor         | Y      | Y      |        | Y      | Y      |        |
+| OpenHW                 | Davide Schiavone      |        |        |        |        |        |        |
+| OpenHW                 | Mike Thompson         | Y      | Y      | Y      |        |        |        |
+| OpenHW                 | Florian Zaruba        | Y      | Y      | Y      | Y      |        |        |


### PR DESCRIPTION
Files changed in program/TWG-and-TG-Attendance-Tracking:

	* TGSoftware_Attendance_2022.md: Add attendance column for 9 May 2022.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>